### PR TITLE
compatiblity fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ consoletests
 *.safetensors
 reqgen.py
 front_end/images
+__pycache__

--- a/Nodes/Dashboard.py
+++ b/Nodes/Dashboard.py
@@ -1,5 +1,5 @@
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import TREE_DASHBOARD
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import PRIMERE_ROOT
+from ..components.tree import TREE_DASHBOARD
+from ..components.tree import PRIMERE_ROOT
 import comfy.samplers
 import folder_paths
 import nodes
@@ -11,11 +11,11 @@ import os
 import tomli
 from .modules.adv_encode import advanced_encode, advanced_encode_XL
 from nodes import MAX_RESOLUTION
-from custom_nodes.ComfyUI_Primere_Nodes.components import utility
+from ..components import utility
 from pathlib import Path
 import re
 import requests
-from custom_nodes.ComfyUI_Primere_Nodes.components import hypernetwork
+from ..components import hypernetwork
 import comfy.sd
 import comfy.utils
 

--- a/Nodes/Inputs.py
+++ b/Nodes/Inputs.py
@@ -1,5 +1,5 @@
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import TREE_INPUTS
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import PRIMERE_ROOT
+from ..components.tree import TREE_INPUTS
+from ..components.tree import PRIMERE_ROOT
 import os
 import re
 from dynamicprompts.parser.parse import ParserConfig
@@ -12,7 +12,7 @@ import hashlib
 from .modules.image_meta_reader import ImageExifReader
 from .modules import exif_data_checker
 import nodes
-from custom_nodes.ComfyUI_Primere_Nodes.components import utility
+from ..components import utility
 from pathlib import Path
 import random
 import string

--- a/Nodes/Networks.py
+++ b/Nodes/Networks.py
@@ -1,8 +1,8 @@
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import TREE_NETWORKS
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import PRIMERE_ROOT
+from ..components.tree import TREE_NETWORKS
+from ..components.tree import PRIMERE_ROOT
 import folder_paths
-from custom_nodes.ComfyUI_Primere_Nodes.components import utility
-from custom_nodes.ComfyUI_Primere_Nodes.components import hypernetwork
+from ..components import utility
+from ..components import hypernetwork
 import comfy.sd
 import comfy.utils
 import os

--- a/Nodes/Outputs.py
+++ b/Nodes/Outputs.py
@@ -1,4 +1,4 @@
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import TREE_OUTPUTS
+from ..components.tree import TREE_OUTPUTS
 import os
 import folder_paths
 import re

--- a/Nodes/Styles.py
+++ b/Nodes/Styles.py
@@ -1,5 +1,5 @@
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import TREE_STYLES
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import PRIMERE_ROOT
+from ..components.tree import TREE_STYLES
+from ..components.tree import PRIMERE_ROOT
 import os
 import tomli
 

--- a/Nodes/Visuals.py
+++ b/Nodes/Visuals.py
@@ -1,9 +1,9 @@
 import nodes
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import TREE_VISUALS
-from custom_nodes.ComfyUI_Primere_Nodes.components.tree import PRIMERE_ROOT
+from ..components.tree import TREE_VISUALS
+from ..components.tree import PRIMERE_ROOT
 import folder_paths
-from custom_nodes.ComfyUI_Primere_Nodes.components import utility
-from custom_nodes.ComfyUI_Primere_Nodes.components import hypernetwork
+from ..components import utility
+from ..components import hypernetwork
 import comfy.sd
 import comfy.utils
 import os

--- a/Nodes/modules/exif/comfyui.py
+++ b/Nodes/modules/exif/comfyui.py
@@ -1,6 +1,6 @@
 import json
 from ..exif.base_format import BaseFormat
-from custom_nodes.ComfyUI_Primere_Nodes.components import utility
+from ....components import utility
 
 # comfyui node types
 KSAMPLER_TYPES = ["KSampler", "KSamplerAdvanced"]

--- a/__init__.py
+++ b/__init__.py
@@ -38,12 +38,12 @@ if frontend_target.exists() == False:
 # else:
 #    print(f"Comfy root probably not found automatically, please copy the folder {frontend_target} manually in the web/extensions folder of ComfyUI")
 
-import custom_nodes.ComfyUI_Primere_Nodes.Nodes.Dashboard as Dashboard
-import custom_nodes.ComfyUI_Primere_Nodes.Nodes.Inputs as Inputs
-import custom_nodes.ComfyUI_Primere_Nodes.Nodes.Styles as Styles
-import custom_nodes.ComfyUI_Primere_Nodes.Nodes.Outputs as Outputs
-import custom_nodes.ComfyUI_Primere_Nodes.Nodes.Visuals as Visuals
-import custom_nodes.ComfyUI_Primere_Nodes.Nodes.Networks as Networks
+from .Nodes import Dashboard as Dashboard
+from .Nodes import Inputs as Inputs
+from .Nodes import Styles as Styles
+from .Nodes import Outputs as Outputs
+from .Nodes import Visuals as Visuals
+from .Nodes import Networks as Networks
 
 NODE_CLASS_MAPPINGS = {
     "PrimereSamplers": Dashboard.PrimereSamplers,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 chardet
-comfy
 dynamicprompts
 nodes
 numpy


### PR DESCRIPTION
* remove `comfy` from requirements.txt
- `comfy` package is breaking ComfyUI totally

* use relative path instead of `custom_nodes.ComfyUI_Primere_Nodes`
- such import method requires `custom_nodes/ComfyUI_Primere_Nodes` but, this repo name is `PrimereComfyNodes`. if user just clone that repository, this extension will be broken due to import failure
- and this ComfyUI-Manager cannot support mismatch of repository name and directory name in custom_nodes